### PR TITLE
gRPC communication + scripts + updated .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,8 @@ build/
 .idea/jarRepositories.xml
 .idea/compiler.xml
 .idea/libraries/
+.idea/protoeditor.xml
+.idea/runConfigurations.xml
 *.iws
 *.iml
 *.ipr

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,12 +24,6 @@ RUN wget "https://services.gradle.org/distributions/gradle-${GRADLE_VERSION}-bin
 
 RUN gradle build
 
-#COPY startup.sh /app/startup.sh
-
-#RUN chmod +x /app/startup.sh
-
-#CMD ["/app/startup.sh"]
-
 CMD ["gradle", "execute"]
 
 

--- a/build.gradle
+++ b/build.gradle
@@ -51,8 +51,16 @@ protobuf {
 }
 
 task execute(type: JavaExec) {
-    main = "gRPCClient.Main"
+    if (project.hasProperty("targetClass")) {
+        main = "gRPCClient.${targetClass}"
+    } else {
+        main = "gRPCClient.Main"
+    }
     classpath = sourceSets.main.runtimeClasspath
+
+    if (project.hasProperty("clientArgs")) {
+        args clientArgs.split(',')
+    }
 }
 
 test {

--- a/scripts/client-1.sh
+++ b/scripts/client-1.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# Attach to server-1 container and run gradle execute command
+docker exec -i server-1 /bin/bash <<EOF
+
+# Run Client.java to connect to server-2
+gradle execute -PtargetClass=Client -PclientArgs=server-2
+
+EOF
+
+# Detach from the container
+exit

--- a/scripts/client-2.sh
+++ b/scripts/client-2.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# Attach to server-1 container and run gradle execute command
+docker exec -i server-2 /bin/bash <<EOF
+
+# Run Client.java to connect to server-2
+gradle execute -PtargetClass=Client -PclientArgs=server-1
+
+EOF
+
+# Detach from the container
+exit

--- a/scripts/docker-setup.sh
+++ b/scripts/docker-setup.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# Set container names as environment variables
+CONTAINER_NAME_SERVER_1=server-1
+CONTAINER_NAME_SERVER_2=server-2
+
+# Create Docker network
+docker network create IndStudyNetwork
+
+# Build Docker image
+docker build -t nodeimage .
+
+# Run containers in detached mode with environment variables
+docker run -d --network IndStudyNetwork --name $CONTAINER_NAME_SERVER_1 -e CONTAINER_NAME=$CONTAINER_NAME_SERVER_1 -p 50051:50051 nodeimage
+docker run -d --network IndStudyNetwork --name $CONTAINER_NAME_SERVER_2 -e CONTAINER_NAME=$CONTAINER_NAME_SERVER_2 -p 50052:50051 nodeimage
+
+echo "Docker setup complete."
+

--- a/shutdown.sh
+++ b/shutdown.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# Stop containers
+docker stop server-1 ; \
+docker stop server-2 ; \
+
+#remove containers
+docker rm server-1 ; \
+docker rm server-2 ; \
+
+# Remove image
+docker rmi nodeimage ; \
+
+# Shutdown and remove network (you can remove the container instances first if they are still running)
+docker network rm IndStudyNetwork
+
+echo "Shutdown and cleanup complete."

--- a/src/main/java/gRPCClient/Client.java
+++ b/src/main/java/gRPCClient/Client.java
@@ -7,32 +7,69 @@ import com.proto.hello.HelloServiceGrpc;
 import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
 
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+
 public class Client {
     public static void main(String[] args) {
-        if(args.length < 2) {
-            System.out.println("Usage: Client <server-ip> <server-port>");
+        String containerName = System.getenv("CONTAINER_NAME");
+        if (containerName == null) {
+            containerName = "Unknown";
+        }
+        int clientID = extractServerNumber(containerName);
+
+        if (args.length < 1) {
+            System.out.println("Usage: Client <container-name>");
             return;
         }
 
-        String serverIP = args[0];
-        int serverPort = Integer.parseInt(args[1]);
+        String targetContainerName = args[0];
 
-        System.out.println("Hello! I'm a running Client stub");
+        System.out.println("Hello! I'm a running Client-"+clientID+" stub");
+        System.out.println("Sending a hello request to "+targetContainerName);
+
+        String targetIpAddress = getContainerIpAddress(targetContainerName);
 
         ManagedChannel channel = ManagedChannelBuilder
-                .forAddress(serverIP, serverPort)
+                .forAddress(targetIpAddress, 50051)
                 .usePlaintext()
                 .build();
 
-        //Create a synchronous client
+        // Create a synchronous client
         HelloServiceGrpc.HelloServiceBlockingStub syncClient = HelloServiceGrpc.newBlockingStub(channel);
-        //Create a protocol buffer message & send it
-        Hello hello = Hello.newBuilder().setClientID(1).build();
+
+        // Create a protocol buffer message & send it
+        Hello hello = Hello.newBuilder().setClientID(clientID).build();
         HelloRequest request = HelloRequest.newBuilder().setHello(hello).build();
+
         HelloResponse response = syncClient.hello(request);
         System.out.println(response.getResult());
 
-        System.out.println("Shutting down ClientOne channel");
+        System.out.println("Shutting down Client-"+clientID+" channel");
         channel.shutdown();
     }
+
+    private static String getContainerIpAddress(String containerName) {
+        try {
+            // Use the container name as the hostname to resolve to its IP address
+            InetAddress inetAddress = InetAddress.getByName(containerName);
+            return inetAddress.getHostAddress();
+        } catch (UnknownHostException e) {
+            e.printStackTrace();
+        }
+        return "Unknown";
+    }
+
+    private static int extractServerNumber(String containerName) {
+        int lastHyphenIndex = containerName.lastIndexOf("-");
+        if (lastHyphenIndex != -1) {
+            try {
+                return Integer.parseInt(containerName.substring(lastHyphenIndex + 1));
+            } catch (NumberFormatException e) {
+                // Ignore and return -1 or handle the error as needed
+            }
+        }
+        return -1; // Unable to extract server number
+    }
 }
+

--- a/src/main/java/gRPCClient/Main.java
+++ b/src/main/java/gRPCClient/Main.java
@@ -9,7 +9,12 @@ import java.util.Enumeration;
 
 public class Main {
     public static void main(String[] args) throws IOException, InterruptedException {
-        System.out.println("Hello! I am a running Server stub");
+        String containerName = System.getenv("CONTAINER_NAME");
+        if (containerName == null) {
+            containerName = "Unknown";
+        }
+
+        System.out.println("Hello! I am a running "+containerName+" stub");
         String containerIpAddress = getContainerIpAddress();
         System.out.println("This server stub is running on IP: "+containerIpAddress);
         io.grpc.Server server = ServerBuilder.forPort(50051)

--- a/src/main/java/gRPCClient/ServerImpl.java
+++ b/src/main/java/gRPCClient/ServerImpl.java
@@ -12,8 +12,14 @@ public class ServerImpl extends HelloServiceGrpc.HelloServiceImplBase {
         Hello hello = request.getHello();
         int clientID = hello.getClientID();
 
+        // Access the CONTAINER_NAME environment variable
+        String containerName = System.getenv("CONTAINER_NAME");
+        if (containerName == null) {
+            containerName = "Unknown";
+        }
+
         //Create Response
-        String result = "Hello Client "+clientID+"! I (Server 1) have acknowledged your message";
+        String result = "Hello Client "+clientID+"! I "+containerName+" have acknowledged your message";
         HelloResponse response = HelloResponse.newBuilder().setResult(result).build();
 
         //Send the response

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+# Make scripts executable
+chmod +x scripts/docker-setup.sh
+chmod +x scripts/client-1.sh
+chmod +x scripts/client-2.sh
+chmod +x shutdown.sh
+
+echo "Scripts setup complete."
+
+# Run the docker-setup.sh script
+./scripts/docker-setup.sh ; \
+
+ echo "Giving 1 minutes for the servers to start up" ; \
+
+# Countdown for 1 minutes
+for ((i = 60; i >= 1; i--)); do
+    echo -ne "Running client-1 in $i seconds...\r"
+    sleep 1
+done
+echo ; \
+
+# Run the client scripts after docker setup
+./scripts/client-1.sh ; \
+
+# Countdown for 10 seconds
+for ((i = 10; i >= 1; i--)); do
+    echo -ne "Running client-2 in $i seconds...\r"
+    sleep 1
+done
+echo ; \
+
+./scripts/client-2.sh
+
+echo "Please run ./shutdown.sh to clean up and remove all docker containers/images/networks."
+

--- a/startup.sh
+++ b/startup.sh
@@ -1,5 +1,0 @@
-# Print classpath
-echo "Classpath: $CLASSPATH"
-
-# Run the application
-gradle execute


### PR DESCRIPTION
To try out the demo of communication between the client and server stubs of different Docker containers:

1- Pull the code to your local machine.
2- Run "chmod +x start.sh".
3- Run "./start.sh".

This will execute a start script that performs the following functions in order:
i- Creates a Docker network and builds a Docker image.
ii- Starts 2 Docker containers within this network.
iii- Runs a countdown for 1 minute to allow the gRPC server (which takes roughly 50 seconds) to be set up inside the 2 Docker containers. (You can check if the servers have started up by either: a) clicking on the container names in Docker Desktop and checking the logs, or b) manually connecting to the Docker container from the terminal and checking for logs.)
iv- Once the servers are set up, client 1 will attempt to send a 'Hello' message to server 2, and server 2 will acknowledge it.
v- Similarly, a 10-second countdown takes place, and client 2 will send a 'Hello' message to server 1, which will be acknowledged.

--- This concludes the demo ---

You can conduct further experiments with gRPC and Docker using this setup. If you have finished with the demo, you can run "./shutdown.sh", which will execute a cleanup script that removes all Docker containers, images, and networks.

If you can successfully run this, feel free to merge it with the main branch.
